### PR TITLE
Fix : add DOMContentLoaded event to prevent a dependency timing issue

### DIFF
--- a/js/wpcf7-dropbox-script.js
+++ b/js/wpcf7-dropbox-script.js
@@ -1,5 +1,5 @@
-jQuery(document).ready(function() {
-    wpcf7_dropbox_mailsent_handler();
+document.addEventListener("DOMContentLoaded", function(event) {
+	wpcf7_dropbox_mailsent_handler();
 });
 
 function wpcf7_dropbox_mailsent_handler() {


### PR DESCRIPTION
If Jquery is attempting to load after i initialize jquery then i get the following message.

`wpcf7-dropbox-script.js:1 Uncaught ReferenceError: jQuery is not defined
    at wpcf7-dropbox-script.js:1`